### PR TITLE
Add the OLM config

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,0 +1,56 @@
+---
+annotations:
+  capabilityLevel: basic install
+  shortDescription: AWS Application Auto Scaling controller is a service controller for managing Application Auto Scaling resources
+    in Kubernetes
+displayName: AWS Controllers for Kubernetes - Amazon Application Auto Scaling
+description: |-
+  Manage Amazon Application Auto Scaling resources in AWS from within your Kubernetes cluster.
+
+  **About Amazon Application Auto Scaling**
+
+  Application Auto Scaling is a web service for developers and system administrators who need a solution for automatically scaling their scalable resources for individual AWS services beyond Amazon EC2. Application Auto Scaling allows you to configure automatic scaling for the following resources:
+
+  - AppStream 2.0 fleets
+
+  - Aurora replicas
+
+  - Amazon Comprehend document classification and entity recognizer endpoints
+
+  - DynamoDB tables and global secondary indexes
+
+  - Amazon Elastic Container Service (ECS) services
+
+  - Amazon EMR clusters
+
+  - Amazon Keyspaces (for Apache Cassandra) tables
+
+  - Lambda function provisioned concurrency
+
+  - Amazon Managed Streaming for Apache Kafka (MSK) broker storage
+
+  - SageMaker endpoint variants
+
+  - Spot Fleet requests
+  
+  - Custom resources provided by your own applications or services. For more information, see the [GitHub repository](https://github.com/aws/aws-auto-scaling-custom-resource)
+
+
+  **About the AWS Controllers for Kubernetes**
+
+
+  This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
+  project. This project is currently in **developer preview**. 
+samples:
+- kind: ScalableTarget
+  spec: '{}'
+- kind: ScalingPolicy
+  spec: '{}'
+- kind: ScheduledAction
+  spec: '{}'
+maintainers:
+- name: "Your Team Name"
+  email: "your-team@example.com"
+links:
+- name: Amazon Application Auto Scaling User Guide
+  url: "https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html"


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

## Related Issue
https://github.com/aws-controllers-k8s/community/issues/744

## Change Description

This PR will add the configuration necessary for the `ack-generate olm` subcommand to render the appropriate Operator Lifecycle Manager ("OLM") bundle assets into the repository.

For reference, the PR merging the `olm` subcommand is here: https://github.com/aws-controllers-k8s/code-generator/commit/cb1d017ccc59feaa7ed247df502a2414f37344b2

This configuration informs `ack-generate` on exactly how to lay down a [ClusterServiceVersion](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md) "kustomize" base, which is then used by Operator SDK to generate a bundle to represent a particular version of the project in OLM

Things to note:

* I just grabbed service information and links from product pages, but those can be changed.
* The maintainer contact information is left with a placeholder and will need to be updated by controller maintainers to an appropriate value before this is put to use.
* The CRDs listed in the samples section were aligned to those found in `config/crd/bases`. As this changes, so do the samples.
* The CRDs listed in the samples section need spec definitions, but for the moment I've specified an empty spec. From an OpenShift Console perspective, this is provided to users as a "template" or "base" for them to reference when attempting to create an instance of the resource through the GUI.

Scripts have already been published to aws-controllers-k8s/community for automating the process of releasing and subsequently generating a bundle. These scripts leverage this configuration and expect them to exist in the controller repository for each service.

https://github.com/aws-controllers-k8s/community/blob/main/scripts/build-controller-release.sh#L182-L196

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-create-bundle.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-build-bundle-image.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-publish-bundle-image.sh

Assuming you have the aws-controllers-k8s/community repo locally available already, as well as your service controller repository, that process looks something like this for an imaginary "v11.0.0" version:

- Generate bundling assets

```shell
cd community # run all scripts from the 
export ACK_GENERATE_OLM=true
./scripts/build-controller-release.sh applicationautoscaling v11.0.0
```

- Create the bundle on disk

```shell
./scripts/olm-create-bundle.sh applicationautoscaling 11.0.0
```

- Publish the bundle to a registry 

```shell
export ADD_RH_CERTIFICATION_LABELS=true
export DOCKER_REPOSITORY=example.com/where/you/are/testing
./scripts/olm-publish-bundle-image.sh applicationautoscaling 11.0.0
```

Here's a quick glimpse as to how the ClusterServiceVersion that is generated from this olmconfig gets generated (I used https://operatorhub.io/preview to get this screenshot):

(note: technically this would render without the run-on entries at the end of the description for "About ACK" as I fixed the spacing issue after I took the screenshot)

![ack-applicationautoscaling-preview](https://user-images.githubusercontent.com/1837593/117217705-6e909b80-adc7-11eb-8393-985529838e1b.png)

