### PR TITLE
Properly capitalize capability level

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,6 +1,6 @@
 ---
 annotations:
-  capabilityLevel: basic install
+  capabilityLevel: Basic Install
   shortDescription: AWS Application Auto Scaling controller is a service controller for managing Application Auto Scaling resources
     in Kubernetes
 displayName: AWS Controllers for Kubernetes - Amazon Application Auto Scaling


### PR DESCRIPTION
This fixes the rendering of the capability level as it shows up in the OpenShift Console. 

Apologies for the extra commit here. The OperatorHub preview functionality used to test the CSV layout is apparently more lenient than the OpenShift Console rendering in this regard.