### PR TITLE
Handle server-side defaults

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -14,14 +14,13 @@ resources:
     hooks:
         sdk_read_many_post_build_request:
           code: rm.customDescribeScalableTarget(ctx, r, input)
+        delta_pre_compare:
+          code: customSetDefaults(a)
         delta_post_compare:
           code: customCompare(a, b, delta)
     fields:
       ResourceID:
         is_name: true
-      SuspendedState:
-        compare:
-          is_ignored: true
       RoleARN:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -14,9 +14,17 @@ resources:
     hooks:
         sdk_read_many_post_build_request:
           code: rm.customDescribeScalableTarget(ctx, r, input)
+        delta_post_compare:
+          code: customCompare(a, b, delta)
     fields:
       ResourceID:
         is_name: true
+      SuspendedState:
+        compare:
+          is_ignored: true
+      RoleARN:
+        compare:
+          is_ignored: true
   ScalingPolicy:
     is_adoptable: false
     fields:

--- a/generator.yaml
+++ b/generator.yaml
@@ -15,15 +15,10 @@ resources:
         sdk_read_many_post_build_request:
           code: rm.customDescribeScalableTarget(ctx, r, input)
         delta_pre_compare:
-          code: customSetDefaults(a)
-        delta_post_compare:
-          code: customCompare(a, b, delta)
+          code: customSetDefaults(a, b)
     fields:
       ResourceID:
         is_name: true
-      RoleARN:
-        compare:
-          is_ignored: true
   ScalingPolicy:
     is_adoptable: false
     fields:

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -15,7 +15,6 @@ package scalable_target
 
 import (
 	"context"
-	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
 )
 
@@ -30,55 +29,5 @@ func (rm *resourceManager) customDescribeScalableTarget(
 	if latestSpec.ResourceID != nil {
 		resourceIDList = append(resourceIDList, latestSpec.ResourceID)
 		input.SetResourceIds(resourceIDList)
-	}
-}
-
-func customCompare(
-	a *resource,
-	b *resource,
-	delta *ackcompare.Delta,
-) {
-	if a.ko.Spec.RoleARN != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
-			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-		} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
-			if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
-				delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-			}
-		}
-	}
-
-	if a.ko.Spec.SuspendedState != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState) {
-			delta.Add("Spec.SuspendedState", a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState)
-		} else if a.ko.Spec.SuspendedState != nil && b.ko.Spec.SuspendedState != nil {
-			if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
-				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended) {
-					delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
-				} else if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
-					if *a.ko.Spec.SuspendedState.DynamicScalingInSuspended != *b.ko.Spec.SuspendedState.DynamicScalingInSuspended {
-						delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
-					}
-				}
-			}
-			if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
-				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended) {
-					delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
-				} else if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
-					if *a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != *b.ko.Spec.SuspendedState.DynamicScalingOutSuspended {
-						delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
-					}
-				}
-			}
-			if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
-				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended) {
-					delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
-				} else if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil && b.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
-					if *a.ko.Spec.SuspendedState.ScheduledScalingSuspended != *b.ko.Spec.SuspendedState.ScheduledScalingSuspended {
-						delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
-					}
-				}
-			}
-		}
 	}
 }

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -15,6 +15,7 @@ package scalable_target
 
 import (
 	"context"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
 )
 
@@ -29,5 +30,55 @@ func (rm *resourceManager) customDescribeScalableTarget(
 	if latestSpec.ResourceID != nil {
 		resourceIDList = append(resourceIDList, latestSpec.ResourceID)
 		input.SetResourceIds(resourceIDList)
+	}
+}
+
+func customCompare(
+	a *resource,
+	b *resource,
+	delta *ackcompare.Delta,
+) {
+	if a.ko.Spec.RoleARN != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
+			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
+		} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
+			if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
+				delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
+			}
+		}
+	}
+
+	if a.ko.Spec.SuspendedState != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState) {
+			delta.Add("Spec.SuspendedState", a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState)
+		} else if a.ko.Spec.SuspendedState != nil && b.ko.Spec.SuspendedState != nil {
+			if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
+				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended) {
+					delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
+				} else if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
+					if *a.ko.Spec.SuspendedState.DynamicScalingInSuspended != *b.ko.Spec.SuspendedState.DynamicScalingInSuspended {
+						delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
+					}
+				}
+			}
+			if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
+				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended) {
+					delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
+				} else if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
+					if *a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != *b.ko.Spec.SuspendedState.DynamicScalingOutSuspended {
+						delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
+					}
+				}
+			}
+			if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
+				if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended) {
+					delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
+				} else if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil && b.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
+					if *a.ko.Spec.SuspendedState.ScheduledScalingSuspended != *b.ko.Spec.SuspendedState.ScheduledScalingSuspended {
+						delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
+					}
+				}
+			}
+		}
 	}
 }

--- a/pkg/resource/scalable_target/custom_delta.go
+++ b/pkg/resource/scalable_target/custom_delta.go
@@ -15,41 +15,27 @@ package scalable_target
 
 import (
 	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
-	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 )
-
-func customCompare(
-	a *resource,
-	b *resource,
-	delta *ackcompare.Delta,
-) {
-	if a.ko.Spec.RoleARN != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
-			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-		} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
-			if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
-				delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-			}
-		}
-	}
-}
 
 func customSetDefaults(
 	a *resource,
+	b *resource,
 ) {
-	defaultValue := false
-	
-	if a.ko.Spec.SuspendedState == nil {
+	if a.ko.Spec.SuspendedState == nil && b.ko.Spec.SuspendedState != nil {
 		a.ko.Spec.SuspendedState = &svcapitypes.SuspendedState{}
 	}
-	if a.ko.Spec.SuspendedState.DynamicScalingInSuspended == nil {
-		a.ko.Spec.SuspendedState.DynamicScalingInSuspended = &defaultValue
+	if a.ko.Spec.SuspendedState.DynamicScalingInSuspended == nil && b.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
+		a.ko.Spec.SuspendedState.DynamicScalingInSuspended = b.ko.Spec.SuspendedState.DynamicScalingInSuspended
 	}
-	if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended == nil {
-		a.ko.Spec.SuspendedState.DynamicScalingOutSuspended = &defaultValue
+	if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended == nil && b.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
+		a.ko.Spec.SuspendedState.DynamicScalingOutSuspended = b.ko.Spec.SuspendedState.DynamicScalingOutSuspended
 	}
-	if a.ko.Spec.SuspendedState.ScheduledScalingSuspended == nil {
-		a.ko.Spec.SuspendedState.ScheduledScalingSuspended = &defaultValue
+	if a.ko.Spec.SuspendedState.ScheduledScalingSuspended == nil && b.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
+		a.ko.Spec.SuspendedState.ScheduledScalingSuspended = b.ko.Spec.SuspendedState.ScheduledScalingSuspended
+	}
+
+	if a.ko.Spec.RoleARN == nil && b.ko.Spec.RoleARN != nil {
+		a.ko.Spec.RoleARN = b.ko.Spec.RoleARN
 	}
 
 }

--- a/pkg/resource/scalable_target/custom_delta.go
+++ b/pkg/resource/scalable_target/custom_delta.go
@@ -1,0 +1,55 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package scalable_target
+
+import (
+	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+func customCompare(
+	a *resource,
+	b *resource,
+	delta *ackcompare.Delta,
+) {
+	if a.ko.Spec.RoleARN != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
+			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
+		} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
+			if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
+				delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
+			}
+		}
+	}
+}
+
+func customSetDefaults(
+	a *resource,
+) {
+	defaultValue := false
+	
+	if a.ko.Spec.SuspendedState == nil {
+		a.ko.Spec.SuspendedState = &svcapitypes.SuspendedState{}
+	}
+	if a.ko.Spec.SuspendedState.DynamicScalingInSuspended == nil {
+		a.ko.Spec.SuspendedState.DynamicScalingInSuspended = &defaultValue
+	}
+	if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended == nil {
+		a.ko.Spec.SuspendedState.DynamicScalingOutSuspended = &defaultValue
+	}
+	if a.ko.Spec.SuspendedState.ScheduledScalingSuspended == nil {
+		a.ko.Spec.SuspendedState.ScheduledScalingSuspended = &defaultValue
+	}
+
+}

--- a/pkg/resource/scalable_target/delta.go
+++ b/pkg/resource/scalable_target/delta.go
@@ -31,7 +31,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	customSetDefaults(a)
+	customSetDefaults(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.MaxCapacity, b.ko.Spec.MaxCapacity) {
 		delta.Add("Spec.MaxCapacity", a.ko.Spec.MaxCapacity, b.ko.Spec.MaxCapacity)
@@ -52,6 +52,13 @@ func newResourceDelta(
 	} else if a.ko.Spec.ResourceID != nil && b.ko.Spec.ResourceID != nil {
 		if *a.ko.Spec.ResourceID != *b.ko.Spec.ResourceID {
 			delta.Add("Spec.ResourceID", a.ko.Spec.ResourceID, b.ko.Spec.ResourceID)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
+		delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
+	} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
+		if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
+			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ScalableDimension, b.ko.Spec.ScalableDimension) {
@@ -94,6 +101,5 @@ func newResourceDelta(
 		}
 	}
 
-	customCompare(a, b, delta)
 	return delta
 }

--- a/pkg/resource/scalable_target/delta.go
+++ b/pkg/resource/scalable_target/delta.go
@@ -53,13 +53,6 @@ func newResourceDelta(
 			delta.Add("Spec.ResourceID", a.ko.Spec.ResourceID, b.ko.Spec.ResourceID)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.RoleARN, b.ko.Spec.RoleARN) {
-		delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-	} else if a.ko.Spec.RoleARN != nil && b.ko.Spec.RoleARN != nil {
-		if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
-			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ScalableDimension, b.ko.Spec.ScalableDimension) {
 		delta.Add("Spec.ScalableDimension", a.ko.Spec.ScalableDimension, b.ko.Spec.ScalableDimension)
 	} else if a.ko.Spec.ScalableDimension != nil && b.ko.Spec.ScalableDimension != nil {
@@ -74,31 +67,7 @@ func newResourceDelta(
 			delta.Add("Spec.ServiceNamespace", a.ko.Spec.ServiceNamespace, b.ko.Spec.ServiceNamespace)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState) {
-		delta.Add("Spec.SuspendedState", a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState)
-	} else if a.ko.Spec.SuspendedState != nil && b.ko.Spec.SuspendedState != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended) {
-			delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
-		} else if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
-			if *a.ko.Spec.SuspendedState.DynamicScalingInSuspended != *b.ko.Spec.SuspendedState.DynamicScalingInSuspended {
-				delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
-			}
-		}
-		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended) {
-			delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
-		} else if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
-			if *a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != *b.ko.Spec.SuspendedState.DynamicScalingOutSuspended {
-				delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
-			}
-		}
-		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended) {
-			delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
-		} else if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil && b.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
-			if *a.ko.Spec.SuspendedState.ScheduledScalingSuspended != *b.ko.Spec.SuspendedState.ScheduledScalingSuspended {
-				delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
-			}
-		}
-	}
 
+	customCompare(a, b, delta)
 	return delta
 }

--- a/pkg/resource/scalable_target/delta.go
+++ b/pkg/resource/scalable_target/delta.go
@@ -31,6 +31,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customSetDefaults(a)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.MaxCapacity, b.ko.Spec.MaxCapacity) {
 		delta.Add("Spec.MaxCapacity", a.ko.Spec.MaxCapacity, b.ko.Spec.MaxCapacity)
@@ -65,6 +66,31 @@ func newResourceDelta(
 	} else if a.ko.Spec.ServiceNamespace != nil && b.ko.Spec.ServiceNamespace != nil {
 		if *a.ko.Spec.ServiceNamespace != *b.ko.Spec.ServiceNamespace {
 			delta.Add("Spec.ServiceNamespace", a.ko.Spec.ServiceNamespace, b.ko.Spec.ServiceNamespace)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState) {
+		delta.Add("Spec.SuspendedState", a.ko.Spec.SuspendedState, b.ko.Spec.SuspendedState)
+	} else if a.ko.Spec.SuspendedState != nil && b.ko.Spec.SuspendedState != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended) {
+			delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
+		} else if a.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingInSuspended != nil {
+			if *a.ko.Spec.SuspendedState.DynamicScalingInSuspended != *b.ko.Spec.SuspendedState.DynamicScalingInSuspended {
+				delta.Add("Spec.SuspendedState.DynamicScalingInSuspended", a.ko.Spec.SuspendedState.DynamicScalingInSuspended, b.ko.Spec.SuspendedState.DynamicScalingInSuspended)
+			}
+		}
+		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended) {
+			delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
+		} else if a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil && b.ko.Spec.SuspendedState.DynamicScalingOutSuspended != nil {
+			if *a.ko.Spec.SuspendedState.DynamicScalingOutSuspended != *b.ko.Spec.SuspendedState.DynamicScalingOutSuspended {
+				delta.Add("Spec.SuspendedState.DynamicScalingOutSuspended", a.ko.Spec.SuspendedState.DynamicScalingOutSuspended, b.ko.Spec.SuspendedState.DynamicScalingOutSuspended)
+			}
+		}
+		if ackcompare.HasNilDifference(a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended) {
+			delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
+		} else if a.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil && b.ko.Spec.SuspendedState.ScheduledScalingSuspended != nil {
+			if *a.ko.Spec.SuspendedState.ScheduledScalingSuspended != *b.ko.Spec.SuspendedState.ScheduledScalingSuspended {
+				delta.Add("Spec.SuspendedState.ScheduledScalingSuspended", a.ko.Spec.SuspendedState.ScheduledScalingSuspended, b.ko.Spec.SuspendedState.ScheduledScalingSuspended)
+			}
 		}
 	}
 


### PR DESCRIPTION
The ScalableTarget Resource has two fields which do not work with the existing ACK CompareResource functionality. This PR fixes this issue by adding these two fields to the ignore list for compare and then adding custom logic. 

More details discussed in [Issue #796](https://github.com/aws-controllers-k8s/community/issues/796)

### Testing
- I tested that the logs were as expected at each step - before any changes; after removing the compare logic entirely; after adding the custom compare function with no changes and finally the custom compare with the new checks. 
- I also checked the logs after manually testing with the suspendedState field added to the spec. 
