### PR TITLE
Fix `service_bootstrap` such that service_cleanup runs and there are no leaking resources

### DIFF
--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -32,8 +32,38 @@ from e2e.bootstrap_resources import TestBootstrapResources, SAGEMAKER_SOURCE_DAT
 def service_bootstrap() -> dict:
     logging.getLogger().setLevel(logging.INFO)
 
-    scalable_table = create_dynamodb_table()
-    registered_table = create_dynamodb_table()
+    try:
+        data_bucket = create_data_bucket()
+    except:
+        data_bucket = ""
+        logging.exception(
+            "Unable to create data bucket"
+        )
+
+    try:
+        execution_role = create_execution_role()
+    except:
+        execution_role = ""
+        logging.exception(
+            "Unable to create execution role"
+        )
+
+    try:
+        scalable_table = create_dynamodb_table()
+    except:
+        scalable_table = ""
+        logging.exception(
+            "Unable to create DynamoDB table"
+        )
+
+    try:
+        registered_table = create_dynamodb_table()
+        register_scalable_dynamodb_table(registered_table)
+    except:
+        registered_table = ""
+        logging.exception(
+            "Unable to create DynamoDB table"
+        )
 
     if not wait_for_dynamodb_table_active(
         scalable_table
@@ -41,10 +71,10 @@ def service_bootstrap() -> dict:
         raise Exception("DynamoDB tables did not become ACTIVE")
 
     return TestBootstrapResources(
-        create_data_bucket(),
-        create_execution_role(),
+        data_bucket,
+        execution_role,
         scalable_table,
-        register_scalable_dynamodb_table(registered_table),
+        registered_table,
     ).__dict__
 
 

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -17,7 +17,7 @@ integration tests.
 import boto3
 import logging
 from time import sleep
-import json
+import json, yaml, os
 import time
 import subprocess
 
@@ -32,38 +32,8 @@ from e2e.bootstrap_resources import TestBootstrapResources, SAGEMAKER_SOURCE_DAT
 def service_bootstrap() -> dict:
     logging.getLogger().setLevel(logging.INFO)
 
-    try:
-        data_bucket = create_data_bucket()
-    except:
-        data_bucket = ""
-        logging.exception(
-            "Unable to create data bucket"
-        )
-
-    try:
-        execution_role = create_execution_role()
-    except:
-        execution_role = ""
-        logging.exception(
-            "Unable to create execution role"
-        )
-
-    try:
-        scalable_table = create_dynamodb_table()
-    except:
-        scalable_table = ""
-        logging.exception(
-            "Unable to create DynamoDB table"
-        )
-
-    try:
-        registered_table = create_dynamodb_table()
-        register_scalable_dynamodb_table(registered_table)
-    except:
-        registered_table = ""
-        logging.exception(
-            "Unable to create DynamoDB table"
-        )
+    scalable_table = create_dynamodb_table("ScalableDynamoTableName")
+    registered_table = create_dynamodb_table("RegisteredDynamoTableName")
 
     if not wait_for_dynamodb_table_active(
         scalable_table
@@ -71,12 +41,21 @@ def service_bootstrap() -> dict:
         raise Exception("DynamoDB tables did not become ACTIVE")
 
     return TestBootstrapResources(
-        data_bucket,
-        execution_role,
+        create_data_bucket(),
+        create_execution_role(),
         scalable_table,
-        registered_table,
+        register_scalable_dynamodb_table(registered_table),
     ).__dict__
 
+def write_bootstrap_config_entry(key: str, value: str, bootstrap_file_name: str = "bootstrap.yaml"):
+    bootstrap_file = bootstrap_directory / bootstrap_file_name
+    config = {key: value}
+
+    if os.path.isfile(bootstrap_file):
+        stream = resources.read_bootstrap_config(bootstrap_directory)
+        config.update(stream)
+    
+    resources.write_bootstrap_config(config, bootstrap_directory)
 
 def create_execution_role() -> str:
     region = get_region()
@@ -115,6 +94,8 @@ def create_execution_role() -> str:
     # resulting in failure that role is not present. So adding a delay
     # to allow for the role to become available
     sleep(10)
+
+    write_bootstrap_config_entry("SageMakerExecutionRoleARN", resource_arn)
     logging.info(f"Created SageMaker execution role {resource_arn}")
 
     return resource_arn
@@ -166,12 +147,13 @@ def create_data_bucket() -> str:
             ["aws", "s3", "sync", f"./{temp_dir}/", f"s3://{bucket_name}", "--quiet"]
         )
 
+    write_bootstrap_config_entry("SageMakerDataBucketName", bucket_name)
     logging.info(f"Synced data bucket")
 
     return bucket_name
 
 
-def create_dynamodb_table() -> str:
+def create_dynamodb_table(table_key: str) -> str:
     """Create a DynamoDB table with a randomised table name.
 
     Returns:
@@ -194,6 +176,8 @@ def create_dynamodb_table() -> str:
     )
 
     assert table["TableDescription"]["TableName"] == table_name
+
+    write_bootstrap_config_entry(table_key, table_name)
     logging.info(f"Created DynamoDB table {table_name}")
 
     return table_name
@@ -259,5 +243,3 @@ def register_scalable_dynamodb_table(table_name: str) -> str:
 
 if __name__ == "__main__":
     config = service_bootstrap()
-    # Write config to current directory by default
-    resources.write_bootstrap_config(config, bootstrap_directory)


### PR DESCRIPTION
### Revision 2 - 
Edited the fix to update each `create_method` to write to to the file directly. This ensures - 
- that there are no extra entries in the bootstrap.yaml file with empty strings. 
- the script exits as soon as there is a resource creation failure and no tests are run. 

TODO: 
- Cleanup is not working at all on python script exit - `make kind-test` exits immediately without running cleanup. 

### Description
#### Issue
if the service_bootstrap.py file fails to create all the resources required, the `service_bootstrap` fails and thus the `bootstrap.yaml` file is not created at all. This means cleanup does not know what resources to delete and these are left hanging behind. Since our accounts by default have a limit of 256 dynamodb tables, we quickly run out of limits leading to further test failures requiring manual cleanup everywhere. 

#### Fix
Ensure that the bootstrap.yaml file is created/written to even if some resources are not created. This guarantees whatever is created is deleted. 

#### Alternate/Original Fixe
Use Try Catch blocks to ensure the `TestBootstrapResources` is written to the `bootstrap.yaml` file even if only partially created.  

### Testing 
I tested by ensuring bucket creation failed and making sure the dynamoDB resources were still created and deleted and the dynamoDB tests ran successfully nevertheless. 