### PR TITLE
Fix canary failures

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 # Build time parameters 
 ARG SERVICE=applicationautoscaling

--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -30,7 +30,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.6/b
  && cp ./kubectl /bin
 
 # Install eksctl
-RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
+ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
 
 # Install Helm 
 RUN curl -q -L "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz" | tar zxf - -C /usr/local/bin/ \

--- a/test/canary/canary.buildspec.yaml
+++ b/test/canary/canary.buildspec.yaml
@@ -10,9 +10,6 @@ phases:
       - aws ecr get-login-password --region $CLUSTER_REGION | docker login --username AWS --password-stdin $ECR_CACHE_URI || true
       - docker pull ${ECR_CACHE_URI}:latest --quiet || true
 
-      # Login to dockerhub to avoid hitting throttle limit
-      - docker login -u $DOCKER_CONFIG_USERNAME -p $DOCKER_CONFIG_PASSWORD
-
       # Build test image
       - >
         docker build -f ./test/canary/Dockerfile.canary . -t ${ECR_CACHE_URI}:latest

--- a/test/e2e/common/sagemaker_utils.py
+++ b/test/e2e/common/sagemaker_utils.py
@@ -93,7 +93,7 @@ def sagemaker_make_endpoint_config(model_name, endpoint_config_name):
                 "VariantName": "variant-1",
                 "ModelName": model_name,
                 "InitialInstanceCount": 1,
-                "InstanceType": "ml.c5.large",
+                "InstanceType": REPLACEMENT_VALUES["ENDPOINT_INSTANCE_TYPE"],
             }
         ],
     }

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -42,8 +42,14 @@ SAGEMAKER_XGBOOST_IMAGE_URIS = {
     "sa-east-1": "737474898029.dkr.ecr.sa-east-1.amazonaws.com",
 }
 
+ENDPOINT_INSTANCE_TYPES = {
+    "eu-west-3": "ml.m5.large",
+    "eu-north-1": "ml.m5.large",
+}
+
 REPLACEMENT_VALUES = {
     "SAGEMAKER_DATA_BUCKET": get_bootstrap_resources().SageMakerDataBucketName,
     "SAGEMAKER_EXECUTION_ROLE_ARN": get_bootstrap_resources().SageMakerExecutionRoleARN,
     "SAGEMAKER_XGBOOST_IMAGE_URI": f"{SAGEMAKER_XGBOOST_IMAGE_URIS[get_region()]}/sagemaker-xgboost:1.0-1-cpu-py3",
+    "ENDPOINT_INSTANCE_TYPE": ENDPOINT_INSTANCE_TYPES.get(get_region(), 'ml.c5.large'),
 }


### PR DESCRIPTION
Description of changes:
- Remove dockerhub login step and use ECR public gallery ubuntu image: Individual user credentials need to be created and registered for all regions to pull from dockerhub. However, this step is redundant when we are already using credentials vended by ECR and can pull from the ECR public gallery. Making this change to facilitate region expansion by avoiding having to create new dockerhub users for each region
- Update eksctl latest git release URL: The URL has been updated and the old URL no longer works
- Implement per region instance type config for canary and e2e tests: Canary tests in the eu-north-1 region are failing since the currently specified instance type requires a limit increase to be used. Implementing a config to specify instance type per region that is within the default limits.

Precedence for changes:

- Remove dockerhub login step and use ECR public gallery ubuntu image: https://github.com/aws-controllers-k8s/sagemaker-controller/commit/2ae5c33433a01c46e743db3e6908c4b19a567328
- Update eksctl latest git release URL: https://github.com/aws-controllers-k8s/sagemaker-controller/pull/87
- Implement per region instance type config for canary and e2e tests: https://github.com/aws-controllers-k8s/sagemaker-controller/pull/87


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
