### PR TITLE
[to-be-closed] Enable AdoptedResource and add required custom logic for ScalableTarget

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-09-13T17:07:52Z"
+  build_date: "2021-09-13T17:26:12Z"
   build_hash: a988bddaea3800999e8a548e0e7a4fd44cc00b19
   go_version: go1.14.14 darwin/amd64
   version: v0.13.2
@@ -7,8 +7,8 @@ api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: 0620a01b0f0a9b954ed28cd12d70feffcef4cc03
+  file_checksum: 56e7824ca9325632a94126f3c1489f45d31e6be6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-13 17:07:59.78168 +0000 UTC
+  timestamp: 2021-09-13 17:26:20.032123 +0000 UTC

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-09-10T21:06:37Z"
+  build_date: "2021-09-13T17:07:52Z"
   build_hash: a988bddaea3800999e8a548e0e7a4fd44cc00b19
   go_version: go1.14.14 darwin/amd64
   version: v0.13.2
@@ -7,8 +7,8 @@ api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: 968c7d8481a61c0299fc373cc6d1692a52b55868
+  file_checksum: 0620a01b0f0a9b954ed28cd12d70feffcef4cc03
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-10 21:06:47.280077 +0000 UTC
+  timestamp: 2021-09-13 17:07:59.78168 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -30,7 +30,7 @@ resources:
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
       set_identifiers_pre_read_one:
-        code: r.customSetIdentifierCode(identifier)
+        code: r.customSetPrimaryIdentifier(identifier)
     fields:
       ResourceID:
         is_name: true

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -15,11 +15,11 @@ operations:
     resource_name: ScalableTarget
   DescribeScalableTargets:
     primary_identifier_field_name: ResourceId
+    custom_check_required_fields_missing_method: customCheckRequiredFieldsMissingMethod
   DescribeScalingPolicies:
     primary_identifier_field_name: ResourceId
 resources:
   ScalableTarget:
-    is_adoptable: false
     hooks:
       sdk_create_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
@@ -29,6 +29,8 @@ resources:
         code: customSetDefaults(a, b)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
+      set_identifiers_pre_read_one:
+        code: r.customSetIdentifierCode(identifier)
     fields:
       ResourceID:
         is_name: true
@@ -43,7 +45,6 @@ resources:
           operation: DescribeScalableTargets
           path: ScalableTargets..CreationTime
   ScalingPolicy:
-    is_adoptable: false
     hooks:
       sdk_create_post_set_output:
         code: rm.customSetLastModifiedTime(ko)

--- a/generator.yaml
+++ b/generator.yaml
@@ -30,7 +30,7 @@ resources:
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
       set_identifiers_pre_read_one:
-        code: r.customSetIdentifierCode(identifier)
+        code: r.customSetPrimaryIdentifier(identifier)
     fields:
       ResourceID:
         is_name: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -15,11 +15,11 @@ operations:
     resource_name: ScalableTarget
   DescribeScalableTargets:
     primary_identifier_field_name: ResourceId
+    custom_check_required_fields_missing_method: customCheckRequiredFieldsMissingMethod
   DescribeScalingPolicies:
     primary_identifier_field_name: ResourceId
 resources:
   ScalableTarget:
-    is_adoptable: false
     hooks:
       sdk_create_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
@@ -29,6 +29,8 @@ resources:
         code: customSetDefaults(a, b)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTime(ko)
+      set_identifiers_pre_read_one:
+        code: r.customSetIdentifierCode(identifier)
     fields:
       ResourceID:
         is_name: true
@@ -43,7 +45,6 @@ resources:
           operation: DescribeScalableTargets
           path: ScalableTargets..CreationTime
   ScalingPolicy:
-    is_adoptable: false
     hooks:
       sdk_create_post_set_output:
         code: rm.customSetLastModifiedTime(ko)

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -16,6 +16,7 @@ package scalable_target
 import (
 	"context"
 	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
@@ -39,4 +40,20 @@ func (rm *resourceManager) customDescribeScalableTarget(
 func (rm *resourceManager) customSetLastModifiedTime(ko *svcapitypes.ScalableTarget) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime
+}
+
+func (r *resource) customSetIdentifierCode(
+	identifier *ackv1alpha1.AWSIdentifiers,
+) {
+	r.ko.Spec.ResourceID = &identifier.NameOrID
+}
+
+// customCheckRequiredFieldsMissingMethod returns true if there are any fields
+// for the ReadOne Input shape that are required but not present in the
+// resource's Spec or Status
+func (rm *resourceManager) customCheckRequiredFieldsMissingMethod(
+	r *resource,
+) bool {
+	return r.ko.Spec.ResourceID == nil
+
 }

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -42,7 +42,9 @@ func (rm *resourceManager) customSetLastModifiedTime(ko *svcapitypes.ScalableTar
 	ko.Status.LastModifiedTime = &currentTime
 }
 
-func (r *resource) customSetIdentifierCode(
+// customSetPrimaryIdentifier sets the ResourceId as the primary Identifier since there is
+// a mismatch in the describe output and inputShape for this resource
+func (r *resource) customSetPrimaryIdentifier(
 	identifier *ackv1alpha1.AWSIdentifiers,
 ) {
 	r.ko.Spec.ResourceID = &identifier.NameOrID

--- a/pkg/resource/scalable_target/manager_factory.go
+++ b/pkg/resource/scalable_target/manager_factory.go
@@ -76,7 +76,7 @@ func (f *resourceManagerFactory) ManagerFor(
 
 // IsAdoptable returns true if the resource is able to be adopted
 func (f *resourceManagerFactory) IsAdoptable() bool {
-	return false
+	return true
 }
 
 // RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds

--- a/pkg/resource/scalable_target/resource.go
+++ b/pkg/resource/scalable_target/resource.go
@@ -105,7 +105,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 		r.ko.Spec.ServiceNamespace = &f4
 	}
 
-	r.customSetIdentifierCode(identifier)
+	r.customSetPrimaryIdentifier(identifier)
 	return nil
 }
 

--- a/pkg/resource/scalable_target/resource.go
+++ b/pkg/resource/scalable_target/resource.go
@@ -105,6 +105,7 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 		r.ko.Spec.ServiceNamespace = &f4
 	}
 
+	r.customSetIdentifierCode(identifier)
 	return nil
 }
 

--- a/pkg/resource/scalable_target/sdk.go
+++ b/pkg/resource/scalable_target/sdk.go
@@ -145,7 +145,7 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return false
+	return rm.customCheckRequiredFieldsMissingMethod(r)
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request

--- a/pkg/resource/scaling_policy/manager_factory.go
+++ b/pkg/resource/scaling_policy/manager_factory.go
@@ -76,7 +76,7 @@ func (f *resourceManagerFactory) ManagerFor(
 
 // IsAdoptable returns true if the resource is able to be adopted
 func (f *resourceManagerFactory) IsAdoptable() bool {
-	return false
+	return true
 }
 
 // RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -20,6 +20,7 @@ from acktest.resources import load_resource_file
 
 SERVICE_NAME = "applicationautoscaling"
 CRD_GROUP = "applicationautoscaling.services.k8s.aws"
+ADOPTED_RESOURCE_CRD_GROUP = "services.k8s.aws"
 CRD_VERSION = "v1alpha1"
 
 # PyTest marker for the current service
@@ -54,6 +55,24 @@ def create_applicationautoscaling_resource(
         CRD_GROUP,
         CRD_VERSION,
         resource_plural,
+        resource_name,
+        spec_file,
+        replacements,
+        namespace,
+    )
+
+    return reference, spec, resource
+
+def create_adopted_resource(resource_name, spec_file, replacements, namespace="default"):
+    """
+    Wrapper around k8s.load_and_create_resource to create a Adopoted resource
+    """
+
+    reference, spec, resource = k8s.load_and_create_resource(
+        resource_directory,
+        ADOPTED_RESOURCE_CRD_GROUP,
+        CRD_VERSION,
+        "adoptedresources",
         resource_name,
         spec_file,
         replacements,

--- a/test/e2e/common/application_autoscaling_utils.py
+++ b/test/e2e/common/application_autoscaling_utils.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+import boto3
+
+def application_autoscaling_client():
+    return boto3.client("application-autoscaling")
+
+def sagemaker_endpoint_register_scalable_target(resource_id):
+    target_input = {
+        "ServiceNamespace": "sagemaker",
+        "ResourceId": resource_id,
+        "ScalableDimension": "sagemaker:variant:DesiredInstanceCount", 
+        "MinCapacity": 1,
+        "MaxCapacity": 2,
+    }
+
+    target_response = application_autoscaling_client().register_scalable_target(**target_input)
+    return target_response
+
+def sagemaker_endpoint_put_scaling_policy(resource_id, policy_name):
+    policy_input = {
+        "PolicyName": policy_name,
+        "ServiceNamespace": "sagemaker",
+        "ResourceId": resource_id,
+        "ScalableDimension": "sagemaker:variant:DesiredInstanceCount", 
+        "PolicyType": "TargetTrackingScaling",
+        "TargetTrackingScalingPolicyConfiguration": {
+            "TargetValue": 70.0,
+            "ScaleInCooldown": 700,
+            "ScaleOutCooldown": 300,
+            "PredefinedMetricSpecification": {
+                "PredefinedMetricType": "SageMakerVariantInvocationsPerInstance",
+            },
+        }
+    }
+
+    policy_response = application_autoscaling_client().put_scaling_policy(**policy_input)
+    return policy_response
+
+def sagemaker_endpoint_deregister_scalable_target(resource_id):
+    target_input = {
+        "ServiceNamespace": "sagemaker",
+        "ResourceId": resource_id,
+        "ScalableDimension": "sagemaker:variant:DesiredInstanceCount", 
+    }
+
+    target_response = application_autoscaling_client().deregister_scalable_target(**target_input)
+    return target_response
+
+def sagemaker_endpoint_delete_scaling_policy(resource_id, policy_name):
+    policy_input = {
+        "ServiceNamespace": "sagemaker",
+        "ResourceId": resource_id,
+        "ScalableDimension": "sagemaker:variant:DesiredInstanceCount", 
+        "PolicyName": policy_name
+    }
+
+    policy_response = application_autoscaling_client().delete_scaling_policy(**policy_input)
+    return policy_response

--- a/test/e2e/resources/sagemaker_endpoint_adopted_policy.yaml
+++ b/test/e2e/resources/sagemaker_endpoint_adopted_policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: services.k8s.aws/v1alpha1
+kind: AdoptedResource
+metadata:
+  name: $ADOPTED_POLICY_NAME
+spec:
+  aws:
+    nameOrID: $RESOURCE_ID
+    additionalKeys:
+      serviceNamespace: sagemaker
+  kubernetes:
+    group: applicationautoscaling.services.k8s.aws
+    kind: ScalingPolicy
+    metadata:
+      name: $ADOPTED_POLICY_NAME

--- a/test/e2e/resources/sagemaker_endpoint_adopted_target.yaml
+++ b/test/e2e/resources/sagemaker_endpoint_adopted_target.yaml
@@ -1,0 +1,15 @@
+apiVersion: services.k8s.aws/v1alpha1
+kind: AdoptedResource
+metadata:
+  name: $ADOPTED_TARGET_NAME
+spec:
+  aws:
+    nameOrID: $RESOURCE_ID
+    additionalKeys:
+      serviceNamespace: "sagemaker"
+      scalableDimension: "sagemaker:variant:DesiredInstanceCount"
+  kubernetes:
+    group: applicationautoscaling.services.k8s.aws
+    kind: ScalableTarget
+    metadata:
+      name: $ADOPTED_TARGET_NAME

--- a/test/e2e/tests/test_adopted_resource.py
+++ b/test/e2e/tests/test_adopted_resource.py
@@ -1,0 +1,199 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the Application Auto Scaling ScalingPolicy API.
+"""
+
+import boto3
+import pytest
+
+from acktest.resources import random_suffix_name
+from acktest.k8s import resource as k8s
+
+from e2e import service_marker, create_adopted_resource
+
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.common.sagemaker_utils import (
+    sagemaker_client,
+    wait_sagemaker_endpoint_status,
+    sagemaker_make_model,
+    sagemaker_make_endpoint_config,
+    sagemaker_make_endpoint,
+)
+from e2e.common.application_autoscaling_utils import (
+    sagemaker_endpoint_register_scalable_target,
+    sagemaker_endpoint_put_scaling_policy,
+    sagemaker_endpoint_deregister_scalable_target,
+    sagemaker_endpoint_delete_scaling_policy,
+)
+
+TARGET_RESOURCE_PLURAL = "scalabletargets"
+POLICY_RESOURCE_PLURAL = "scalingpolicies"
+ENDPOINT_STATUS_INSERVICE = "InService"
+CRD_GROUP = "applicationautoscaling.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+
+@pytest.fixture(scope="module")
+def name_suffix():
+    return random_suffix_name("sagemaker-endpoint", 32)
+
+
+@pytest.fixture(scope="module")
+def applicationautoscaling_client():
+    return boto3.client("application-autoscaling")
+
+
+@pytest.fixture(scope="module")
+def sagemaker_endpoint(name_suffix):
+    model_name = name_suffix + "-model"
+    endpoint_config_name = name_suffix + "-config"
+    endpoint_name = name_suffix
+    resource_id = f"endpoint/{endpoint_name}/variant/variant-1"
+
+    _, _ = sagemaker_make_model(model_name)
+    _, _ = sagemaker_make_endpoint_config(
+        model_name, endpoint_config_name
+    )
+    _, _ = sagemaker_make_endpoint(
+        endpoint_name, endpoint_config_name
+    )
+
+    wait_sagemaker_endpoint_status(endpoint_name, ENDPOINT_STATUS_INSERVICE)
+    assert resource_id is not None
+
+    yield resource_id
+    sagemaker_client().delete_endpoint(EndpointName=endpoint_name)
+    sagemaker_client().delete_endpoint_config(EndpointConfigName=endpoint_config_name)
+    sagemaker_client().delete_model(ModelName=model_name)
+
+
+@pytest.fixture(scope="module")
+def register_scalable_target(sagemaker_endpoint):
+    resource_id = sagemaker_endpoint
+    _ = sagemaker_endpoint_register_scalable_target(
+        resource_id
+    )
+
+    yield resource_id
+    sagemaker_endpoint_deregister_scalable_target(resource_id)
+
+@pytest.fixture(scope="module")
+def put_scaling_policy(register_scalable_target):
+    resource_id = register_scalable_target
+    policy_name = random_suffix_name("policy_name", 32)
+    _ = sagemaker_endpoint_put_scaling_policy(
+        resource_id, policy_name
+    )
+
+    yield resource_id
+    sagemaker_endpoint_delete_scaling_policy(resource_id, policy_name)
+
+
+@pytest.fixture(scope="module")
+def adopt_scalable_target(sagemaker_endpoint):
+    resource_id = sagemaker_endpoint
+    target_resource_name = random_suffix_name("sagemaker-scalable-target", 32)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["ADOPTED_TARGET_NAME"] = target_resource_name
+    replacements["RESOURCE_ID"] = resource_id
+
+    adopted_target_reference, _, adopted_target_resource = create_adopted_resource(
+        resource_name=target_resource_name,
+        spec_file="sagemaker_endpoint_adopted_target",
+        replacements=replacements,
+    )
+
+    assert adopted_target_resource is not None
+
+    yield (resource_id, adopted_target_reference)
+
+    if k8s.get_resource_exists(adopted_target_reference):
+        _, deleted = k8s.delete_custom_resource(adopted_target_reference)
+        assert deleted
+
+
+@pytest.fixture(scope="module")
+def adopt_scaling_policy(adopt_scalable_target):
+    resource_id, adopted_target_reference = adopt_scalable_target
+    policy_resource_name = random_suffix_name("sagemaker-scaling-policy", 32)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["ADOPTED_POLICY_NAME"] = policy_resource_name
+    replacements["RESOURCE_ID"] = resource_id
+
+    adopted_policy_reference, _, adopted_policy_resource = create_adopted_resource(
+        resource_name=policy_resource_name,
+        spec_file="sagemaker_endpoint_adopted_policy",
+        replacements=replacements,
+    )
+
+    assert adopted_policy_resource is not None
+
+    yield (resource_id, adopted_target_reference, adopted_policy_reference)
+
+    if k8s.get_resource_exists(adopted_policy_reference):
+        _, deleted = k8s.delete_custom_resource(adopted_policy_reference)
+        assert deleted
+
+
+@service_marker
+@pytest.mark.canary
+class TestAdoptedSageMakerEndpointAutoscaling:
+    def test_smoke(self, put_scaling_policy, adopt_scaling_policy):
+        sdk_resource_id = put_scaling_policy
+
+        (   adopted_resource_id,
+            adopted_target_reference,
+            adopted_policy_reference,
+        ) = adopt_scaling_policy
+
+        assert sdk_resource_id == adopted_resource_id
+
+        target_name = k8s.get_resource(adopted_target_reference)["spec"]["kubernetes"]["metadata"]["name"]
+        policy_name = k8s.get_resource(adopted_policy_reference)["spec"]["kubernetes"]["metadata"]["name"]
+
+        assert target_name is not None
+        assert policy_name is not None
+
+        for reference in (
+            adopted_target_reference,
+            adopted_policy_reference,
+        ):
+            assert k8s.wait_on_condition(reference, "ACK.Adopted", "True")
+
+        target_reference = k8s.create_reference(
+            CRD_GROUP, CRD_VERSION, TARGET_RESOURCE_PLURAL, target_name, "default"
+        )
+        target_resource = k8s.wait_resource_consumed_by_controller(target_reference)
+        assert target_resource is not None
+
+        assert target_resource["spec"].get("resourceID", None) == sdk_resource_id
+
+        policy_reference = k8s.create_reference(
+            CRD_GROUP, CRD_VERSION, POLICY_RESOURCE_PLURAL, policy_name, "default"
+        )
+        policy_resource = k8s.wait_resource_consumed_by_controller(policy_reference)
+        assert policy_resource is not None
+
+        assert policy_resource["spec"].get("resourceID", None) == sdk_resource_id
+        
+
+
+        # Delete the Resource
+        _, deleted = k8s.delete_custom_resource(adopted_policy_reference)
+        assert deleted is True
+
+        _, deleted = k8s.delete_custom_resource(adopted_target_reference)
+        assert deleted is True
+        


### PR DESCRIPTION
Description of changes:
 - Enable AdoptedResource for both resources
 - Add required custom logic for ScalableTarget 
 - Add integration test for the same

Testing
- Manually verified that scalableTarget can be adopted
- Local Kind tests pass 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
