### PR TITLE
Use the CreationTime to update LastModifiedTime 

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,6 +1,6 @@
 ack_generate_info:
-  build_date: "2021-09-15T07:47:20Z"
-  build_hash: 5a4809a4882a9beb39c737529907a3ebaff3910c
+  build_date: "2021-09-16T00:51:44Z"
+  build_hash: 29a44ff03ae7d871faa8603c6ee9885cab5abd92
   go_version: go1.14.14
   version: v0.14.0
 api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-09-16T00:50:09Z"
-  build_hash: 29a44ff03ae7d871faa8603c6ee9885cab5abd92
+  build_date: "2021-09-15T07:47:20Z"
+  build_hash: 5a4809a4882a9beb39c737529907a3ebaff3910c
   go_version: go1.14.14
   version: v0.14.0
 api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: 29e4b90575aecda2a6d32c4f016616e95f365c6d
+  file_checksum: baa788a6de90973eba7fbee7ee1f146c803186f8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-09-16T00:00:15Z"
+  build_date: "2021-09-16T00:50:09Z"
   build_hash: 29a44ff03ae7d871faa8603c6ee9885cab5abd92
   go_version: go1.14.14
   version: v0.14.0
@@ -7,7 +7,7 @@ api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: b9cb2cfa6c027466a00a98d2031047d9edaa648a
+  file_checksum: 29e4b90575aecda2a6d32c4f016616e95f365c6d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -18,7 +18,7 @@ operations:
 resources:
   ScalableTarget:
     hooks:
-      sdk_create_post_set_output:
+      sdk_read_many_post_set_output:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_read_many_post_build_request:
         code: rm.customDescribeScalableTarget(ctx, r, input)
@@ -41,7 +41,7 @@ resources:
           path: ScalableTargets..CreationTime
   ScalingPolicy:
     hooks:
-      sdk_create_post_set_output:
+      sdk_read_many_post_set_output:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTimeToCurrentTime(ko)

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -19,13 +19,13 @@ resources:
   ScalableTarget:
     hooks:
       sdk_create_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_read_many_post_build_request:
         code: rm.customDescribeScalableTarget(ctx, r, input)
       delta_pre_compare:
         code: customSetDefaults(a, b)
       sdk_update_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCurrentTime(ko)
     fields:
       ResourceID:
         is_primary_key: true
@@ -42,9 +42,9 @@ resources:
   ScalingPolicy:
     hooks:
       sdk_create_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCurrentTime(ko)
     fields:
       ResourceID:
         is_primary_key: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -18,7 +18,7 @@ operations:
 resources:
   ScalableTarget:
     hooks:
-      sdk_create_post_set_output:
+      sdk_read_many_post_set_output:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_read_many_post_build_request:
         code: rm.customDescribeScalableTarget(ctx, r, input)
@@ -41,7 +41,7 @@ resources:
           path: ScalableTargets..CreationTime
   ScalingPolicy:
     hooks:
-      sdk_create_post_set_output:
+      sdk_read_many_post_set_output:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTimeToCurrentTime(ko)

--- a/generator.yaml
+++ b/generator.yaml
@@ -19,13 +19,13 @@ resources:
   ScalableTarget:
     hooks:
       sdk_create_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_read_many_post_build_request:
         code: rm.customDescribeScalableTarget(ctx, r, input)
       delta_pre_compare:
         code: customSetDefaults(a, b)
       sdk_update_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCurrentTime(ko)
     fields:
       ResourceID:
         is_primary_key: true
@@ -42,9 +42,9 @@ resources:
   ScalingPolicy:
     hooks:
       sdk_create_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
-        code: rm.customSetLastModifiedTime(ko)
+        code: rm.customSetLastModifiedTimeToCurrentTime(ko)
     fields:
       ResourceID:
         is_primary_key: true

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -35,8 +35,13 @@ func (rm *resourceManager) customDescribeScalableTarget(
 	}
 }
 
+// customSetOutputUpdate sets the LastModifiedTime field to the creationTime
+func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalableTarget) {
+	ko.Status.LastModifiedTime = ko.Status.CreationTime
+}
+
 // customSetOutputUpdate sets the LastModifiedTime field to the current time post an update
-func (rm *resourceManager) customSetLastModifiedTime(ko *svcapitypes.ScalableTarget) {
+func (rm *resourceManager) customSetLastModifiedTimeToCurrentTime(ko *svcapitypes.ScalableTarget) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime
 }

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -37,7 +37,9 @@ func (rm *resourceManager) customDescribeScalableTarget(
 
 // customSetOutputUpdate sets the LastModifiedTime field to the creationTime
 func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalableTarget) {
-	ko.Status.LastModifiedTime = ko.Status.CreationTime
+	if ko.Status.CreationTime != nil && ko.Status.LastModifiedTime == nil {
+		ko.Status.LastModifiedTime = ko.Status.CreationTime
+	}
 }
 
 // customSetOutputUpdate sets the LastModifiedTime field to the current time post an update

--- a/pkg/resource/scalable_target/custom_api.go
+++ b/pkg/resource/scalable_target/custom_api.go
@@ -35,14 +35,14 @@ func (rm *resourceManager) customDescribeScalableTarget(
 	}
 }
 
-// customSetOutputUpdate sets the LastModifiedTime field to the creationTime
+// customSetLastModifiedTimeToCreationTime sets the LastModifiedTime field to the creationTime
 func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalableTarget) {
 	if ko.Status.CreationTime != nil && ko.Status.LastModifiedTime == nil {
 		ko.Status.LastModifiedTime = ko.Status.CreationTime
 	}
 }
 
-// customSetOutputUpdate sets the LastModifiedTime field to the current time post an update
+// customSetLastModifiedTimeToCurrentTime sets the LastModifiedTime field to the current time post an update
 func (rm *resourceManager) customSetLastModifiedTimeToCurrentTime(ko *svcapitypes.ScalableTarget) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime

--- a/pkg/resource/scalable_target/sdk.go
+++ b/pkg/resource/scalable_target/sdk.go
@@ -194,7 +194,7 @@ func (rm *resourceManager) sdkCreate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTime(ko)
+	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 
@@ -269,7 +269,7 @@ func (rm *resourceManager) sdkUpdate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTime(ko)
+	rm.customSetLastModifiedTimeToCurrentTime(ko)
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/scalable_target/sdk.go
+++ b/pkg/resource/scalable_target/sdk.go
@@ -138,6 +138,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 
@@ -194,7 +195,6 @@ func (rm *resourceManager) sdkCreate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/scaling_policy/custom_api.go
+++ b/pkg/resource/scaling_policy/custom_api.go
@@ -19,8 +19,13 @@ import (
 	"time"
 )
 
+// customSetOutputUpdate sets the LastModifiedTime field to the creationTime
+func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalingPolicy) {
+	ko.Status.LastModifiedTime = ko.Status.CreationTime
+}
+
 // customSetOutputUpdate sets the LastModifiedTime field to the current time post an update
-func (rm *resourceManager) customSetLastModifiedTime(ko *svcapitypes.ScalingPolicy) {
+func (rm *resourceManager) customSetLastModifiedTimeToCurrentTime(ko *svcapitypes.ScalingPolicy) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime
 }

--- a/pkg/resource/scaling_policy/custom_api.go
+++ b/pkg/resource/scaling_policy/custom_api.go
@@ -19,14 +19,14 @@ import (
 	"time"
 )
 
-// customSetOutputUpdate sets the LastModifiedTime field to the creationTime
+// customSetLastModifiedTimeToCreationTime sets the LastModifiedTime field to the creationTime
 func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalingPolicy) {
 	if ko.Status.CreationTime != nil && ko.Status.LastModifiedTime == nil {
 		ko.Status.LastModifiedTime = ko.Status.CreationTime
 	}
 }
 
-// customSetOutputUpdate sets the LastModifiedTime field to the current time post an update
+// customSetLastModifiedTimeToCurrentTime sets the LastModifiedTime field to the current time post an update
 func (rm *resourceManager) customSetLastModifiedTimeToCurrentTime(ko *svcapitypes.ScalingPolicy) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime

--- a/pkg/resource/scaling_policy/custom_api.go
+++ b/pkg/resource/scaling_policy/custom_api.go
@@ -21,7 +21,9 @@ import (
 
 // customSetOutputUpdate sets the LastModifiedTime field to the creationTime
 func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapitypes.ScalingPolicy) {
-	ko.Status.LastModifiedTime = ko.Status.CreationTime
+	if ko.Status.CreationTime != nil && ko.Status.LastModifiedTime == nil {
+		ko.Status.LastModifiedTime = ko.Status.CreationTime
+	}
 }
 
 // customSetOutputUpdate sets the LastModifiedTime field to the current time post an update

--- a/pkg/resource/scaling_policy/sdk.go
+++ b/pkg/resource/scaling_policy/sdk.go
@@ -316,7 +316,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTime(ko)
+	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 
@@ -488,7 +488,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTime(ko)
+	rm.customSetLastModifiedTimeToCurrentTime(ko)
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/scaling_policy/sdk.go
+++ b/pkg/resource/scaling_policy/sdk.go
@@ -233,6 +233,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 
@@ -316,7 +317,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customSetLastModifiedTimeToCreationTime(ko)
 	return &resource{ko}, nil
 }
 

--- a/test/e2e/tests/test_adopted_resource.py
+++ b/test/e2e/tests/test_adopted_resource.py
@@ -143,7 +143,9 @@ def adopt_scaling_policy(adopt_scalable_target):
 @service_marker
 @pytest.mark.canary
 class TestAdopted:
-    def test_sagemaker_endpoint_autoscaling(self, put_scaling_policy, adopt_scaling_policy):
+    def test_sagemaker_endpoint_autoscaling(
+        self, put_scaling_policy, adopt_scaling_policy
+    ):
         sdk_resource_id = put_scaling_policy
 
         (

--- a/test/e2e/tests/test_sagemaker_endpoint_autoscaling.py
+++ b/test/e2e/tests/test_sagemaker_endpoint_autoscaling.py
@@ -83,7 +83,11 @@ def generate_sagemaker_target(sagemaker_endpoint):
     replacements["SCALABLETARGET_NAME"] = target_resource_name
     replacements["RESOURCE_ID"] = resource_id
 
-    target_reference, target_spec, target_resource = create_applicationautoscaling_resource(
+    (
+        target_reference,
+        target_spec,
+        target_resource,
+    ) = create_applicationautoscaling_resource(
         resource_plural=TARGET_RESOURCE_PLURAL,
         resource_name=target_resource_name,
         spec_file="sagemaker_endpoint_autoscaling_target",
@@ -101,14 +105,23 @@ def generate_sagemaker_target(sagemaker_endpoint):
 
 @pytest.fixture(scope="module")
 def generate_sagemaker_policy(generate_sagemaker_target):
-    resource_id, target_reference, target_spec, target_resource = generate_sagemaker_target
+    (
+        resource_id,
+        target_reference,
+        target_spec,
+        target_resource,
+    ) = generate_sagemaker_target
     policy_resource_name = random_suffix_name("sagemaker-scaling-policy", 32)
 
     replacements = REPLACEMENT_VALUES.copy()
     replacements["SCALINGPOLICY_NAME"] = policy_resource_name
     replacements["RESOURCE_ID"] = resource_id
 
-    policy_reference, policy_spec, policy_resource = create_applicationautoscaling_resource(
+    (
+        policy_reference,
+        policy_spec,
+        policy_resource,
+    ) = create_applicationautoscaling_resource(
         resource_plural=POLICY_RESOURCE_PLURAL,
         resource_name=policy_resource_name,
         spec_file="sagemaker_endpoint_autoscaling_policy",
@@ -117,7 +130,15 @@ def generate_sagemaker_policy(generate_sagemaker_target):
 
     assert policy_resource is not None
 
-    yield (resource_id, target_reference, target_spec, target_resource, policy_resource, policy_spec, policy_reference)
+    yield (
+        resource_id,
+        target_reference,
+        target_spec,
+        target_resource,
+        policy_resource,
+        policy_spec,
+        policy_reference,
+    )
 
     if k8s.get_resource_exists(policy_reference):
         _, deleted = k8s.delete_custom_resource(policy_reference)
@@ -128,7 +149,7 @@ def generate_sagemaker_policy(generate_sagemaker_target):
 @pytest.mark.canary
 class TestSageMakerEndpointAutoscaling:
     def wait_until_update(
-        self, reference, previous_modified_time, wait_period=30, wait_time=5
+        self, reference, previous_modified_time, wait_period=2, wait_time=30
     ):
         for i in range(wait_period):
             resource = k8s.get_resource(reference)
@@ -180,7 +201,9 @@ class TestSageMakerEndpointAutoscaling:
     def test_create(self, applicationautoscaling_client, generate_sagemaker_policy):
         (
             resource_id,
-            target_reference, target_spec, target_resource,
+            target_reference,
+            target_spec,
+            target_resource,
             policy_resource,
             policy_spec,
             policy_reference,
@@ -205,7 +228,9 @@ class TestSageMakerEndpointAutoscaling:
     def test_update(self, applicationautoscaling_client, generate_sagemaker_policy):
         (
             resource_id,
-            target_reference, target_spec, target_resource,
+            target_reference,
+            target_spec,
+            target_resource,
             policy_resource,
             policy_spec,
             policy_reference,
@@ -213,43 +238,46 @@ class TestSageMakerEndpointAutoscaling:
 
         updatedMaxCapacity = 4
         updatedTargetValue = 120
-        
+
         # Update the ScalableTarget
         target_spec["spec"]["maxCapacity"] = updatedMaxCapacity
         assert "lastModifiedTime" in target_resource["status"]
         last_modified_time = target_resource["status"]["lastModifiedTime"]
         k8s.patch_custom_resource(target_reference, target_spec)
         assert self.wait_until_update(target_reference, last_modified_time) == True
-        sleep(5)
-        
+
         updated_target_description = self.get_sagemaker_scalable_target_description(
             applicationautoscaling_client, resource_id, 1
         )
         assert updated_target_description is not None
-        assert (
-            updated_target_description[0]["MaxCapacity"] == updatedMaxCapacity
-        )
+        assert updated_target_description[0]["MaxCapacity"] == updatedMaxCapacity
 
         # Update the ScalingPolicy
-        policy_spec["spec"]["targetTrackingScalingPolicyConfiguration"]["targetValue"] = updatedTargetValue
+        policy_spec["spec"]["targetTrackingScalingPolicyConfiguration"][
+            "targetValue"
+        ] = updatedTargetValue
         assert "lastModifiedTime" in policy_resource["status"]
         last_modified_time = policy_resource["status"]["lastModifiedTime"]
         k8s.patch_custom_resource(policy_reference, policy_spec)
         assert self.wait_until_update(policy_reference, last_modified_time) == True
-        sleep(5)
 
         updated_policy_description = self.get_sagemaker_scaling_policy_description(
             applicationautoscaling_client, resource_id, 1
         )
         assert updated_policy_description is not None
         assert (
-            updated_policy_description[0]["TargetTrackingScalingPolicyConfiguration"]["TargetValue"] == updatedTargetValue
+            updated_policy_description[0]["TargetTrackingScalingPolicyConfiguration"][
+                "TargetValue"
+            ]
+            == updatedTargetValue
         )
 
     def test_delete(self, applicationautoscaling_client, generate_sagemaker_policy):
         (
             resource_id,
-            target_reference, target_spec, target_resource,
+            target_reference,
+            target_spec,
+            target_resource,
             policy_resource,
             policy_spec,
             policy_reference,

--- a/test/e2e/tests/test_sagemaker_endpoint_autoscaling.py
+++ b/test/e2e/tests/test_sagemaker_endpoint_autoscaling.py
@@ -16,6 +16,7 @@
 import boto3
 import botocore
 import pytest
+import datetime
 import logging
 from typing import Dict, Tuple
 


### PR DESCRIPTION
Issue #, if available:
Fixing [comment](https://github.com/aws-controllers-k8s/applicationautoscaling-controller/pull/40#pullrequestreview-751856481) on previous PR #40 

Description of changes:
 - Use the CreationTime to update LastModifiedTime 
 - Add associated test to check LastModifiedTime

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
