### PR TITLE
install helm 3.7 for canary tests

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -33,7 +33,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.6/b
  RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp && mv /tmp/eksctl /bin
 
 # Install Helm 
-RUN curl -q -L "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz" | tar zxf - -C /usr/local/bin/ \
+RUN curl -q -L "https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz" | tar zxf - -C /usr/local/bin/ \
  && mv /usr/local/bin/linux-amd64/helm /usr/local/bin/helm \
  && rm -r /usr/local/bin/linux-amd64 \
  && chmod +x /usr/local/bin/helm 


### PR DESCRIPTION
Description of changes:
Latest release of `applicationautoscaling` will use `helm` 3.7 and the current helm installation will now longer be compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
