### PR TITLE
Add policy arn for application-autoscaling

### DIFF
--- a/config/iam/recommended-policy-arn
+++ b/config/iam/recommended-policy-arn
@@ -1,0 +1,1 @@
+arn:aws:iam::aws:policy/PowerUserAccess


### PR DESCRIPTION
Description of changes:
Tough to come up with a solid policy-arn for application-autoscaling for now will default to poweruser

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
