### PR TITLE
Release artifacts for release v0.2.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2021-10-08T22:00:03Z"
+  build_date: "2021-10-20T20:39:00Z"
   build_hash: 1eaee0ea592ad5752cb9d403e2c13e9a7bdb8d33
   go_version: go1.17.1
   version: v0.15.1
-api_directory_checksum: a13caf20935ebb6193efdee1ab377cae33311ad7
+api_directory_checksum: f74933ce367600826bd1c18d8f23df43e98f7140
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: applicationautoscaling-chart
 description: A Helm chart for the ACK service controller for AWS Auto Scaling (AutoScaling)
-version: v0.1.1
-appVersion: v0.1.1
+version: v0.2.0
+appVersion: v0.2.0
 home: https://github.com/aws-controllers-k8s/applicationautoscaling-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/applicationautoscaling-controller
-  tag: v0.1.1
+  tag: v0.2.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/scalable_target/manager_test_suite_test.go
+++ b/pkg/resource/scalable_target/manager_test_suite_test.go
@@ -17,10 +17,10 @@ import (
 	"errors"
 	"fmt"
 
+	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
 	"github.com/aws-controllers-k8s/applicationautoscaling-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/applicationautoscaling-controller/test/mocks/aws-sdk-go/applicationautoscaling"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -68,7 +68,7 @@ func cleanup(filename string) {
 	err := os.Remove(filename)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		panic("The specified file could not be deleted")
-		}
+	}
 }
 
 // Checks to see if the contents of a given yaml file, with name stored


### PR DESCRIPTION
Release Notes Draft:

- Added `ScalableTarget` unit tests #56 
- Added `ScalaingPolicy` unit tests #57
- Helm image is updated to be Helm 3.7 compatible #58 
  -  ⚠️ **Breaking Change** Helm versions < `3.7` are no longer compatible
- Update ACK Runtime from `0.14.0` to `0.15.1` #62 
  - ⚠️ **Breaking Change** `aws-account-id` can no longer be set and has been removed from the charts.
  - Please refer to https://github.com/aws-controllers-k8s/runtime/releases for a detailed list of changes 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
