### PR TITLE
ACK runtime update to v0.19.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-15T17:19:34Z"
-  build_hash: 50c64871bcaf88b9ee200eb8d6b8245fa8f675eb
+  build_date: "2022-06-14T04:56:33Z"
+  build_hash: a133935a9a93591a9e1ba9d5ca940cb83a1353b4
   go_version: go1.17.5
-  version: v0.18.4
+  version: v0.19.0
 api_directory_checksum: 6a10685980ee0dfddcf83fb3555f58e31d1e24c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 08f4d14e9bb9273756d31cdfea0a101a5642ce66
+  file_checksum: b2ac33cc79c75dfc65066ea3fca66ad781d4ae18
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -42,6 +42,8 @@ resources:
       RoleARN:
         late_initialize:
           min_backoff_seconds: 5
+    tags:
+      ignore: true
   ScalingPolicy:
     hooks:
       sdk_read_many_post_set_output:
@@ -63,6 +65,8 @@ resources:
         from:
           operation: DescribeScalingPolicies
           path: ScalingPolicies..CreationTime
+    tags:
+      ignore: true
 ignore:
     resource_names:
       - ScheduledAction

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	ackrtwebhook "github.com/aws-controllers-k8s/runtime/pkg/webhook"
 	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
@@ -102,7 +103,7 @@ func main() {
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
-		ackrt.VersionInfo{
+		acktypes.VersionInfo{
 			version.GitCommit,
 			version.GitVersion,
 			version.BuildDate,

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         - name: ACK_LOG_LEVEL
           value: "info"
         - name: ACK_RESOURCE_TAGS
-          value: "services.k8s.aws/managed=true,services.k8s.aws/created=%UTCNOW%,services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%"
+          value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/applicationautoscaling-controller
-  newTag: v0.2.9
+  newTag: v0.2.10

--- a/generator.yaml
+++ b/generator.yaml
@@ -42,6 +42,8 @@ resources:
       RoleARN:
         late_initialize:
           min_backoff_seconds: 5
+    tags:
+      ignore: true
   ScalingPolicy:
     hooks:
       sdk_read_many_post_set_output:
@@ -63,6 +65,8 @@ resources:
         from:
           operation: DescribeScalingPolicies
           path: ScalingPolicies..CreationTime
+    tags:
+      ignore: true
 ignore:
     resource_names:
       - ScheduledAction

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/applicationautoscaling-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.18.4
+	github.com/aws-controllers-k8s/runtime v0.19.0
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.18.4 h1:iwLYNwhbuiWZrHPoulGj75oT+alE91wCNkF1FUELiAw=
-github.com/aws-controllers-k8s/runtime v0.18.4/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
+github.com/aws-controllers-k8s/runtime v0.19.0 h1:+O5a6jBSBAd8XTNMrVCIYu4G+ZUPZe/G5eopVFO18Dc=
+github.com/aws-controllers-k8s/runtime v0.19.0/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: applicationautoscaling-chart
 description: A Helm chart for the ACK service controller for AWS Auto Scaling (AutoScaling)
-version: v0.2.9
-appVersion: v0.2.9
+version: v0.2.10
+appVersion: v0.2.10
 home: https://github.com/aws-controllers-k8s/applicationautoscaling-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/applicationautoscaling-controller:v0.2.9".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/applicationautoscaling-controller:v0.2.10".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/applicationautoscaling-controller
-  tag: v0.2.9
+  tag: v0.2.10
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -64,9 +64,8 @@ installScope: cluster
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on
   # resources that it manages.
-  - services.k8s.aws/managed=true
-  - services.k8s.aws/created=%UTCNOW%
-  - services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%
+  - services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%
+  - services.k8s.aws/namespace=%K8S_NAMESPACE%
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/pkg/resource/scalable_target/manager.go
+++ b/pkg/resource/scalable_target/manager.go
@@ -27,19 +27,25 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	"github.com/aws/aws-sdk-go/aws/session"
+	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
-	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
+	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
 )
 
 var (
 	_ = ackutil.InStrings
+	_ = acktags.NewTags()
+	_ = ackrt.MissingImageTagValue
+	_ = svcapitypes.ScalableTarget{}
 )
 
 // +kubebuilder:rbac:groups=applicationautoscaling.services.k8s.aws,resources=scalabletargets,verbs=get;list;watch;create;update;patch;delete
@@ -266,6 +272,22 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 	}
 
 	return true, nil
+}
+
+// EnsureTags ensures that tags are present inside the AWSResource.
+// If the AWSResource does not have any existing resource tags, the 'tags'
+// field is initialized and the controller tags are added.
+// If the AWSResource has existing resource tags, then controller tags are
+// added to the existing resource tags without overriding them.
+// If the AWSResource does not support tags, only then the controller tags
+// will not be added to the AWSResource.
+func (rm *resourceManager) EnsureTags(
+	ctx context.Context,
+	res acktypes.AWSResource,
+	md acktypes.ServiceControllerMetadata,
+) error {
+
+	return nil
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/scaling_policy/manager.go
+++ b/pkg/resource/scaling_policy/manager.go
@@ -27,19 +27,25 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	"github.com/aws/aws-sdk-go/aws/session"
+	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
-	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
-	svcsdkapi "github.com/aws/aws-sdk-go/service/applicationautoscaling/applicationautoscalingiface"
+	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
 )
 
 var (
 	_ = ackutil.InStrings
+	_ = acktags.NewTags()
+	_ = ackrt.MissingImageTagValue
+	_ = svcapitypes.ScalingPolicy{}
 )
 
 // +kubebuilder:rbac:groups=applicationautoscaling.services.k8s.aws,resources=scalingpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -257,6 +263,22 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 	}
 
 	return true, nil
+}
+
+// EnsureTags ensures that tags are present inside the AWSResource.
+// If the AWSResource does not have any existing resource tags, the 'tags'
+// field is initialized and the controller tags are added.
+// If the AWSResource has existing resource tags, then controller tags are
+// added to the existing resource tags without overriding them.
+// If the AWSResource does not support tags, only then the controller tags
+// will not be added to the AWSResource.
+func (rm *resourceManager) EnsureTags(
+	ctx context.Context,
+	res acktypes.AWSResource,
+	md acktypes.ServiceControllerMetadata,
+) error {
+
+	return nil
 }
 
 // newResourceManager returns a new struct implementing


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1338

Description of changes:
* Update ACK runtime to v0.19.0
* Ignore tags for ScalableTarget, ScalingPolicy because these resources do not support AWS tags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
