### PR TITLE
Set `policyName` in `DescribeScalingPolicies` input request

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-05-15T22:45:51Z"
+  build_date: "2023-06-26T18:59:44Z"
   build_hash: 8f3ba427974fd6e769926778d54834eaee3b81a3
-  go_version: go1.19
+  go_version: go1.20.1
   version: v0.26.1
 api_directory_checksum: 81d152c4602b014d435a9ba3d716ed5112273013
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: b2ac33cc79c75dfc65066ea3fca66ad781d4ae18
+  file_checksum: e5f40f1e7ac3be9113553960bfcb5945c7c08ab7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -50,6 +50,8 @@ resources:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTimeToCurrentTime(ko)
+      sdk_read_many_post_build_request:
+        code: rm.customDescribeScalingPolicies(ctx, r, input)
     fields:
       ResourceID:
         is_primary_key: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -50,6 +50,8 @@ resources:
         code: rm.customSetLastModifiedTimeToCreationTime(ko)
       sdk_update_post_set_output:
         code: rm.customSetLastModifiedTimeToCurrentTime(ko)
+      sdk_read_many_post_build_request:
+        code: rm.customDescribeScalingPolicies(ctx, r, input)
     fields:
       ResourceID:
         is_primary_key: true

--- a/pkg/resource/scaling_policy/custom_api.go
+++ b/pkg/resource/scaling_policy/custom_api.go
@@ -14,9 +14,12 @@
 package scaling_policy
 
 import (
-	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
 	"time"
+
+	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
+	svcsdk "github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // customSetLastModifiedTimeToCreationTime sets the LastModifiedTime field to the creationTime
@@ -30,4 +33,19 @@ func (rm *resourceManager) customSetLastModifiedTimeToCreationTime(ko *svcapityp
 func (rm *resourceManager) customSetLastModifiedTimeToCurrentTime(ko *svcapitypes.ScalingPolicy) {
 	currentTime := metav1.Time{Time: time.Now().UTC()}
 	ko.Status.LastModifiedTime = &currentTime
+}
+
+// customDescribeScalingPolicies sets the policy name in DescribeScalingPoliciesInput
+func (rm *resourceManager) customDescribeScalingPolicies(
+	ctx context.Context,
+	latest *resource,
+	input *svcsdk.DescribeScalingPoliciesInput,
+) {
+	spec := latest.ko.Spec
+
+	var policyNames []*string
+	if spec.PolicyName != nil {
+		policyNames = append(policyNames, spec.PolicyName)
+		input.SetPolicyNames(policyNames)
+	}
 }

--- a/pkg/resource/scaling_policy/sdk.go
+++ b/pkg/resource/scaling_policy/sdk.go
@@ -72,6 +72,7 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+	rm.customDescribeScalingPolicies(ctx, r, input)
 	var resp *svcsdk.DescribeScalingPoliciesOutput
 	resp, err = rm.sdkapi.DescribeScalingPoliciesWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_MANY", "DescribeScalingPolicies", err)


### PR DESCRIPTION
When calling `ReadOne` for `ScalingPolicies` the controller does not set
`policyName` into the input causing it to list all the policies related to a
resource and (possibly) pick the wrong one. This PR adds to a controller
the ability to set a policyName to the request, making it easier to read the
latest state.

Description of changes:
- Set `policyName` in `DescribeScalingPolicies` input request

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
