### PR TITLE
Add IAM Role reference to ScalableTarget.RoleARN

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:35:30Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
-api_directory_checksum: f4e56af7c09e3d7a35c82f0f1aa9f210fb83fb79
+  build_date: "2026-06-22T19:07:11Z"
+  build_hash: 7bd233ce4497717ee64e21327c9d52c7c38290fe
+  go_version: go1.26.0
+  version: v0.59.1-17-g7bd233c
+api_directory_checksum: a76eafdbecfd28c5149ce80fc598f25fc60f3389
 api_version: v1alpha1
-aws_sdk_go_version: 1.32.6
+aws_sdk_go_version: v1.35.0
 generator_config_info:
-  file_checksum: c896ebe9258f323742e43e0bf4b000bb4acbafd7
+  file_checksum: 3042db1da0084d7a072def5d267da40d8d944720
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -46,6 +46,10 @@ resources:
       RoleARN:
         late_initialize:
           min_backoff_seconds: 5
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
     tags:
       ignore: true
   ScalingPolicy:

--- a/apis/v1alpha1/scalable_target.go
+++ b/apis/v1alpha1/scalable_target.go
@@ -150,7 +150,8 @@ type ScalableTargetSpec struct {
 	// information, see How Application Auto Scaling works with IAM (https://docs.aws.amazon.com/autoscaling/application/userguide/security_iam_service-with-iam.html).
 	//
 	// Regex Pattern: `^[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*$`
-	RoleARN *string `json:"roleARN,omitempty"`
+	RoleARN *string                                  `json:"roleARN,omitempty"`
+	RoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"roleRef,omitempty"`
 	// The scalable dimension associated with the scalable target. This string consists
 	// of the service namespace, resource type, and scaling property.
 	//

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -185,7 +185,8 @@ type PredictiveScalingMetricStat struct {
 	Unit   *string                  `json:"unit,omitempty"`
 }
 
-// Represents a predictive scaling policy configuration.
+// Represents a predictive scaling policy configuration. Predictive scaling
+// is supported on Amazon ECS services.
 type PredictiveScalingPolicyConfiguration struct {
 	MaxCapacityBreachBehavior *string                                 `json:"maxCapacityBreachBehavior,omitempty"`
 	MaxCapacityBuffer         *int64                                  `json:"maxCapacityBuffer,omitempty"`
@@ -268,7 +269,8 @@ type ScalingPolicy_SDK struct {
 	PolicyARN    *string      `json:"policyARN,omitempty"`
 	PolicyName   *string      `json:"policyName,omitempty"`
 	PolicyType   *string      `json:"policyType,omitempty"`
-	// Represents a predictive scaling policy configuration.
+	// Represents a predictive scaling policy configuration. Predictive scaling
+	// is supported on Amazon ECS services.
 	PredictiveScalingPolicyConfiguration *PredictiveScalingPolicyConfiguration `json:"predictiveScalingPolicyConfiguration,omitempty"`
 	ResourceID                           *string                               `json:"resourceID,omitempty"`
 	ScalableDimension                    *string                               `json:"scalableDimension,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -635,6 +635,11 @@ func (in *ScalableTargetSpec) DeepCopyInto(out *ScalableTargetSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RoleRef != nil {
+		in, out := &in.RoleRef, &out.RoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ScalableDimension != nil {
 		in, out := &in.ScalableDimension, &out.ScalableDimension
 		*out = new(string)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -57,6 +58,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/applicationautoscaling.services.k8s.aws_scalabletargets.yaml
+++ b/config/crd/bases/applicationautoscaling.services.k8s.aws_scalabletargets.yaml
@@ -177,6 +177,23 @@ spec:
 
                   Regex Pattern: `^[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*$`
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               scalableDimension:
                 description: |-
                   The scalable dimension associated with the scalable target. This string consists

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -45,6 +45,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/generator.yaml
+++ b/generator.yaml
@@ -46,6 +46,10 @@ resources:
       RoleARN:
         late_initialize:
           min_backoff_seconds: 5
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
     tags:
       ignore: true
   ScalingPolicy:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/aws-controllers-k8s/applicationautoscaling-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.59.1
+	github.com/aws-controllers-k8s/iam-controller v1.7.1
+	github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.34.10

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/runtime v0.59.1 h1:7UDKl9/dif8oNjxx/5Z5ciUfuyn86MS4BvoG9LqF6h4=
-github.com/aws-controllers-k8s/runtime v0.59.1/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
+github.com/aws-controllers-k8s/iam-controller v1.7.1 h1:vr3vooNq1QXbgXe6eDJP5hxFE1sAZKSmqYM7oN9lwgU=
+github.com/aws-controllers-k8s/iam-controller v1.7.1/go.mod h1:+DkPEaeclPVtdzmaJTXgUJwylxu/3pu98/Z485VVLMA=
+github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01 h1:1kdTtKwkVyw5KnOt9/5b0+e3OZ55EcwTTDw9AvfnKWU=
+github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=

--- a/helm/crds/applicationautoscaling.services.k8s.aws_scalabletargets.yaml
+++ b/helm/crds/applicationautoscaling.services.k8s.aws_scalabletargets.yaml
@@ -177,6 +177,23 @@ spec:
 
                   Regex Pattern: `^[\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\r\n\t]*$`
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               scalableDimension:
                 description: |-
                   The scalable dimension associated with the scalable target. This string consists

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -92,6 +92,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -99,6 +99,7 @@ spec:
         - "$(FEATURE_GATES)"
 {{- end }}
         - --enable-carm={{ .Values.enableCARM }}
+        - --enable-cross-namespace={{ .Values.enableCrossNamespace }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -275,6 +275,11 @@
       "type": "boolean",
       "default": true
    },
+    "enableCrossNamespace": {
+      "description": "Enable cross-namespace behavior (resource references, secret references, field exports). When false, the controller rejects any operation that crosses namespace boundaries.",
+      "type": "boolean",
+      "default": true
+   },
     "serviceAccount": {
       "description": "ServiceAccount settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -176,6 +176,11 @@ leaderElection:
 # Enable Cross Account Resource Management (default = true). Set this to false to disable cross account resource management.
 enableCARM: true
 
+# Enable cross-namespace behavior including resource references, secret references,
+# and field exports (default = true). When false, the controller rejects any operation
+# that crosses namespace boundaries.
+enableCrossNamespace: true
+
 # Configuration for feature gates.  These are optional controller features that
 # can be individually enabled ("true") or disabled ("false") by adding key/value
 # pairs below.

--- a/pkg/resource/scalable_target/delta.go
+++ b/pkg/resource/scalable_target/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -69,6 +70,9 @@ func newResourceDelta(
 		if *a.ko.Spec.RoleARN != *b.ko.Spec.RoleARN {
 			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.RoleRef, b.ko.Spec.RoleRef) {
+		delta.Add("Spec.RoleRef", a.ko.Spec.RoleRef, b.ko.Spec.RoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ScalableDimension, b.ko.Spec.ScalableDimension) {
 		delta.Add("Spec.ScalableDimension", a.ko.Spec.ScalableDimension, b.ko.Spec.ScalableDimension)

--- a/pkg/resource/scalable_target/references.go
+++ b/pkg/resource/scalable_target/references.go
@@ -17,13 +17,23 @@ package scalable_target
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/applicationautoscaling-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -31,6 +41,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.RoleRef != nil {
+		ko.Spec.RoleARN = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +61,116 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.ScalableTarget) error {
+
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("RoleARN", "RoleRef")
+	}
+	return nil
+}
+
+// resolveReferenceForRoleARN reads the resource referenced
+// from RoleRef field and sets the RoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ScalableTarget,
+) (hasReferences bool, err error) {
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.RoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: RoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.RoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }


### PR DESCRIPTION
## Description
Add cross-resource reference from ScalableTarget.RoleARN to IAM Role, identified by the ACK scanner gap analysis tool.

### Changes
- **ScalableTarget**: Add IAM Role reference to `RoleARN` field, allowing users to reference an ACK-managed IAM Role directly

### Testing
- Code generated successfully with `make build-controller`
- Controller compiles: `go build -o bin/controller ./cmd/controller`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.